### PR TITLE
add centos 7 build support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,7 @@
 AC_INIT([mod_authnz_crowd], m4_esyscmd([./version-gen]), [support@atlassian.com])
 AM_INIT_AUTOMAKE([-Wall foreign])
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+LT_INIT
 AC_PROG_CC
 AC_PROG_LIBTOOL
 AC_CONFIG_HEADERS([config.h])
@@ -64,7 +66,9 @@ AC_CHECK_FILE([/usr/local/apache2/bin/apxs], [APXS="/usr/local/apache2/bin/apxs"
     AC_CHECK_FILE([/usr/sbin/apxs], [APXS="/usr/sbin/apxs"], [
         AC_CHECK_FILE([/usr/bin/apxs2], [APXS="/usr/bin/apxs2"], [
             AC_CHECK_FILE([/usr/sbin/apxs2], [APXS="/usr/sbin/apxs2"], [
-                AC_MSG_ERROR([Could not locate Apache apxs binary])
+                AC_CHECK_FILE([/usr/bin/apxs], [APXS="/usr/bin/apxs"], [
+                    AC_MSG_ERROR([Could not locate Apache apxs binary])
+                ])
             ])
         ])
     ])

--- a/packages/mod_authnz_crowd.spec
+++ b/packages/mod_authnz_crowd.spec
@@ -1,5 +1,5 @@
 Name:           mod_authnz_crowd
-Version:        2.1
+Version:        2.2.2
 Release:        1%{?dist}
 Summary:        Modules for integrating Apache httpd and Subversion with Atlassian Crowd
 
@@ -43,7 +43,12 @@ rm -rf $RPM_BUILD_ROOT
 %doc LICENSE
 
 %post
-/usr/sbin/apxs -e -a -n authnz_crowd mod_authnz_crowd.so
+%if 0%{?rhel} >= 7
+APXS=/usr/bin/apxs
+%else
+APXS=/usr/sbin/apxs
+%endif
+$APXS -e -a -n authnz_crowd mod_authnz_crowd.so
 cat << END > /tmp/httpd.conf.sed
 /^[ \t]*[Ll][Oo][Aa][Dd][Mm][Oo][Dd][Uu][Ll][Ee][ \t]\+authz_svn_module[ \t]/ {
     s/^/# /

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,9 +3,9 @@ SUBDIRS = svn
 lib_LTLIBRARIES = mod_authnz_crowd.la
 mod_authnz_crowd_la_SOURCES = mod_authnz_crowd.c mod_authnz_crowd.h crowd_client.c crowd_client.h cache.c cache.h util.c util.h
 mod_authnz_crowd_la_LDFLAGS = -module -lcurl `xml2-config --libs`
+mod_authnz_crowd_la_CFLAGS = -g -Wmissing-prototypes -O1
 AM_CFLAGS = `apr-1-config --cflags`
 AM_CPPFLAGS = -I@APACHE_INCLUDE_DIR@ `apr-1-config --cppflags --includes` `xml2-config --cflags`
-CFLAGS=-g -Wmissing-prototypes -O1   # -O2 causes mysterious crashes
 TESTS = test.py
 TESTS_ENVIRONMENT = APACHE_BIN_DIR=@APACHE_BIN_DIR@
 

--- a/src/crowd_client.c
+++ b/src/crowd_client.c
@@ -631,7 +631,7 @@ static char *make_app_cache_key(const request_rec *r, const crowd_config *config
 }
 
 static char *make_session_cache_key(const char *token, const char *forwarded_for, const request_rec *r, const crowd_config *config) {
-#if AP_MODULE_MAGIC_AT_LEAST(20080403,1)
+#if AP_MODULE_MAGIC_AT_LEAST(20080403,1) || AP_MODULE_MAGIC_AT_LEAST(20120211,24)
     return log_ralloc(r, apr_psprintf(r->pool, "%s\037%s\037%s\037%s\037%s", token,
         forwarded_for == NULL ? "" : forwarded_for, r->connection->client_ip, config->crowd_app_name,
         config->crowd_url));
@@ -770,7 +770,7 @@ static bool handle_crowd_create_session_session_element(write_data_t *write_data
 }
 
 static const char *get_validation_factors(const request_rec *r, const char *forwarded_for) {
-#if AP_MODULE_MAGIC_AT_LEAST(20080403,1)
+#if AP_MODULE_MAGIC_AT_LEAST(20080403,1) || AP_MODULE_MAGIC_AT_LEAST(20120211,24)
     const char *payload_beginning = log_ralloc(r, apr_pstrcat(r->pool,
         "<validation-factors><validation-factor><name>remote_address</name><value>", r->connection->client_ip,
         "</value></validation-factor>", NULL));

--- a/src/mod_authnz_crowd.c
+++ b/src/mod_authnz_crowd.c
@@ -610,7 +610,7 @@ apr_array_header_t *authnz_crowd_user_groups(const char *username, request_rec *
  * @param r the current request
  * @return OK, DECLINED, or HTTP_...
  */
-#if AP_MODULE_MAGIC_AT_LEAST(20080403,1)
+#if AP_MODULE_MAGIC_AT_LEAST(20080403,1) || AP_MODULE_MAGIC_AT_LEAST(20120211,24)
 static authz_status auth_group_checker(request_rec *r,
                  const char *require_line,
                  const void *parsed_require_args) {

--- a/src/svn/Makefile.am
+++ b/src/svn/Makefile.am
@@ -1,6 +1,6 @@
 lib_LTLIBRARIES = mod_authz_svn_crowd.la
 mod_authz_svn_crowd_la_SOURCES = mod_authz_svn_crowd.c
 mod_authz_svn_crowd_la_LDFLAGS = -module
+mod_authz_svn_crowd_la_CFLAGS = -g -O1
 AM_CFLAGS = `apr-1-config --cflags`
 AM_CPPFLAGS = -I@APACHE_INCLUDE_DIR@ `apr-1-config --cppflags --includes` -I@SVN_DIR@/include/subversion-1
-CFLAGS=-g -O1   # -O2 causes mysterious crashes


### PR DESCRIPTION
Hi,

this PR allow to build crowd connector on CentOS 7 with compatibility on CentOS6/5. In addition i've fixed some warnings/error in autoconf 2.69.
