### PR TITLE
fixed for svn 1.8 issue: exit signal Segmentation fault 

### DIFF
--- a/src/svn/mod_authz_svn_crowd.c
+++ b/src/svn/mod_authz_svn_crowd.c
@@ -50,6 +50,7 @@
 
 #include <svn_pools.h>
 #include <svn_dirent_uri.h>
+#include <svn_version.h>
 
 const char *
 svn_fspath__canonicalize(const char *fspath,
@@ -73,6 +74,7 @@ typedef struct authz_svn_config_rec {
   const char *base_path;
   const char *access_file;
   const char *repo_relative_access_file;
+  const char *groups_file; // rwb
   const char *force_username_case;
 } authz_svn_config_rec;
 
@@ -105,6 +107,12 @@ struct svn_config_t
   /* Temporary value used for expanded default values in svn_config_get.
      (Using a stringbuf so that frequent resetting is efficient.) */
   svn_stringbuf_t *tmp_value;
+  
+  #if SVN_VER_MINOR >= 7
+  /* Specifies whether section names are populated case sensitively. */
+  svn_boolean_t section_names_case_sensitive;
+  #endif
+
 };
 
 typedef struct
@@ -113,7 +121,7 @@ typedef struct
   const char *name;
 
   /* The section name, converted into a hash key. */
-  const char *hash_key;
+  //const char *hash_key;
 
   /* Table of cfg_option_t's. */
   apr_hash_t *options;


### PR DESCRIPTION
fixed for svn 1.8 issue: exit signal Segmentation fault 

from:
https://bitbucket.org/atlassian/cwdapache/pull-requests/18/added-apache-24-compatibility-and-fixed/diff#comment-2439987